### PR TITLE
Fix typo: Change 'ext' to 'text' in ONBOARDING.md

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -158,7 +158,7 @@ The functionality of FarmData2 is tested using the [Cypress framework](https://w
 The Cypress end-to-end test framework works by controlling the web browser. A test typically consists of a series of steps that are automated by the Cypress tests, called _spec_s. A typical spec consist of the steps:
   1. Setup the test (e.g. login, prime the database)
   1. Visit a specific page
-  1. Query the page for an _html element_ of interest (e.g. button, ext field)
+  1. Query the page for an _html element_ of interest (e.g. button, text field)
   1. Interact with that element (e.g. click the button, enter some text)
   1. Make an assertion about the result (e.g. new information appears on the page)
 


### PR DESCRIPTION
__Pull Request Description__

Changed "ext" to "text" in the phrase " (e.g. button, ext field)" at the end of bullet point 3 under "End-To-End" tests in the "Cypress" section of ONBOARDING.md.
Fixes #7 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
