### PR TITLE
Add Link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ As a reference, the basic steps for working with GitHub Flow are as follows:
   * Go to the [FarmData2 Repository] (the _upstream_)
   * Fork the _upstream_ repository to your GitHub (the _origin_).
   * [Clone] the _origin_ repository to your local machine.
-  * Set the  _upstream_ remote for your local repository to point to the _upstream_ repository.
+  * [Set the  _upstream_ remote](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-repository-for-a-fork) for your local repository to point to the _upstream_ repository.
   * Create a _feature branch_ from the _main_ branch your local machine.
   * Make the edits to the documentation or the code in your _feature branch_.
   * Commit your edits.


### PR DESCRIPTION
__Pull Request Description__

Makes the phrase "Set the upstream remote" a link to appropriate documentation in the 4th bullet point of the "Workflow" section within the CONTRIBUTING document.

Fixes #16.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
