### PR TITLE
Changed 'Fork' to a link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ FarmData2 generally uses the [GitHub flow](https://guides.github.com/introductio
 As a reference, the basic steps for working with GitHub Flow are as follows:
 
   * Go to the [FarmData2 Repository] (the _upstream_)
-  * Fork the _upstream_ repository to your GitHub (the _origin_).
+  * [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the _upstream_ repository to your GitHub (the _origin_).
   * [Clone] the _origin_ repository to your local machine.
   * Set the  _upstream_ remote for your local repository to point to the _upstream_ repository.
   * Create a _feature branch_ from the _main_ branch your local machine.
@@ -94,3 +94,4 @@ As a reference, the basic steps for working with GitHub Flow are as follows:
 [Clone]: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/cloning-a-repository
 [FarmData2 Repository]: https://github.com/DickinsonCollege/FarmData2
 [Creating a commit with multiple authors]: https://docs.github.com/en/free-pro-team@latest/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
+


### PR DESCRIPTION
__Pull Request Description__

The word "Fork" in the section labelled  "Workflow" in the CONTRIBUTING.md file has been changed to a link which explains how to fork a repository.

Fixes #18 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
