### PR TITLE
Fix Mention of Authors in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -29,6 +29,6 @@ All other content, including code snippets posted in public forums, is licensed 
 
 #### Attribution ####
 
-Attribution of contributions to the FarmData2 repository are maintained in the logs of the git version control system.  The [AUTHORS.md](AUTHORS.md) file contains a list of all contributors to the repository and is updated periodically.
+Attribution of contributions to the FarmData2 repository are maintained in the logs of the git version control system. 
 
 Attribution of content in public forums is typically maintained by the appropriate forum (e.g. threads, usernames, cross linked issues, etc). If not however, it is the contributor's responsibility to ensure that proper attribution is made based.


### PR DESCRIPTION
Fixing the Mention of Authors in LICENSE.md

There was a string of text that was not supposed to be embedded within the LICENSE.md file. I went into the file and edited it to remove the mention of the authors and to fix this error.

Closes #25

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
